### PR TITLE
Support for the navigation structure of the Observation app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,7 @@ jobs:
         run: echo "//npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}" >> .npmrc && cat .npmrc
       - name: Install modules
         run: yarn
+      - name: Run eslint
+        run: yarn lint
+      - name: Run tests with coverage
+        run: yarn test --coverage --silent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         run: echo "//npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}" >> .npmrc && cat .npmrc
       - name: Install modules
         run: yarn
-      - name: Run eslint
+      - name: Run lint
         run: yarn lint
       - name: Run tests with coverage
         run: yarn test --coverage --silent

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { StyleSheet, View, Text, ViewStyle, StyleProp } from 'react-native'
 
+import { useTheme } from '@react-navigation/native'
+
 import LargeButton, { LargeButtonProps } from './LargeButton'
 import textStyle from '../styles/text'
 import theme from '../styles/theme'
@@ -15,10 +17,11 @@ type Props = {
 }
 
 const BottomSheet = ({ title, text, buttons = [], style, testID, children }: Props) => {
+  const { colors } = useTheme()
   const buttonsMarginTop = title || text ? theme.margin.common : 0
   return (
     <View style={[styles.container, style]} testID={testID}>
-      <View style={styles.bottomSheetContainer}>
+      <View style={[styles.bottomSheetContainer, { backgroundColor: colors.card }]}>
         <View style={styles.bottomSheet}>
           <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
             {title && (
@@ -70,7 +73,6 @@ const styles = StyleSheet.create({
     borderTopColor: theme.color.greySemi,
   },
   bottomSheetContainer: {
-    backgroundColor: 'white',
     ...theme.shadow.android,
   },
   bottomSheet: {

--- a/src/components/DocumentLink.tsx
+++ b/src/components/DocumentLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
 
-import { IconInfo } from './Icon'
+import { IconDocument } from './Icon'
 import IconText from './IconText'
 import textStyle from '../styles/text'
 import theme from '../styles/theme'
@@ -13,9 +13,9 @@ type Props = {
   label: string
 }
 
-const MoreInfo = ({ onPress, containerStyle, label }: Props) => (
+const DocumentLink = ({ onPress, containerStyle, label }: Props) => (
   <IconText
-    icon={<IconInfo size={theme.icon.size.medium} />}
+    icon={<IconDocument size={theme.icon.size.medium} />}
     text={label}
     style={{
       containerStyle,
@@ -25,4 +25,4 @@ const MoreInfo = ({ onPress, containerStyle, label }: Props) => (
   />
 )
 
-export default MoreInfo
+export default DocumentLink

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -79,6 +79,7 @@ export const IconDate = (props: IconAppearanceProps) => <Icon name="date" {...pr
 export const IconDateRange = (props: IconAppearanceProps) => <Icon name="date-range" {...props} />
 export const IconDelete = (props: IconAppearanceProps) => <Icon name="delete" {...props} />
 export const IconDisclose = (props: IconAppearanceProps) => <Icon name="disclose" {...props} />
+export const IconDocument = (props: IconAppearanceProps) => <Icon name="document" {...props} />
 export const IconEnumeration = (props: IconAppearanceProps) => <Icon name="enumeration" {...props} />
 export const IconError = (props: IconAppearanceProps) => <Icon name="error" {...props} />
 export const IconErrorMessage = (props: IconAppearanceProps) => <Icon name="error-message" {...props} />

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -89,6 +89,7 @@ export const IconImageGallery = (props: IconAppearanceProps) => <Icon name="imag
 export const IconInfo = (props: IconAppearanceProps) => <Icon name="info" {...props} />
 export const IconList = (props: IconAppearanceProps) => <Icon name="list" {...props} />
 export const IconLocation = (props: IconAppearanceProps) => <Icon name="location" {...props} />
+export const IconLogin = (props: IconAppearanceProps) => <Icon name="login" {...props} />
 export const IconNext = (props: IconAppearanceProps) => <Icon name="next" {...props} />
 export const IconPhotography = (props: IconAppearanceProps) => <Icon name="photography" {...props} />
 export const IconPlayback = (props: IconAppearanceProps) => <Icon name="playback" {...props} />

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -31,6 +31,7 @@ const defaultProps: { [key in IconName]?: IconAppearanceProps } = {
   count: { color: white80 },
   date: { style: 'solid', color: greySemi, size: medium },
   disclose: { size: extraLarge },
+  document: { style: 'solid' },
   email: { style: 'solid' },
   enumeration: { style: 'solid' },
   error: { color: error },

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -54,6 +54,7 @@ const defaultProps: { [key in IconName]?: IconAppearanceProps } = {
   selection: { color: black },
   show: { style: 'solid' },
   success: { color: success },
+  'tab-add': { size: extraExtraLarge },
   user: { color: greySemi },
   'validation-accepted-by-admin': { style: 'solid', size: theme.icon.size.medium },
   'validation-accepted-with-evidence': { color: success, style: 'solid', size: theme.icon.size.medium },
@@ -106,6 +107,7 @@ export const IconSelection = (props: IconAppearanceProps) => <Icon name="selecti
 export const IconSettings = (props: IconAppearanceProps) => <Icon name="settings" {...props} />
 export const IconStatistics = (props: IconAppearanceProps) => <Icon name="statistics" {...props} />
 export const IconSuccess = (props: IconAppearanceProps) => <Icon name="success" {...props} />
+export const IconTabAdd = (props: IconAppearanceProps) => <Icon name="tab-add" {...props} />
 export const IconUpload = (props: IconAppearanceProps) => <Icon name="upload" {...props} />
 export const IconUser = (props: IconAppearanceProps) => <Icon name="user" {...props} />
 export const IconUserInactive = (props: IconAppearanceProps) => <Icon name="user-inactive" {...props} />

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -11,11 +11,13 @@ type Props = {
   containerStyle?: StyleProp<ViewStyle>
   testID?: string
   label: string
+  icon?: JSX.Element
 }
 
-const MoreInfo = ({ onPress, containerStyle, label }: Props) => (
+const defaultIcon = <IconInfo size={theme.icon.size.medium} />
+const MoreInfo = ({ onPress, containerStyle, icon = defaultIcon, label }: Props) => (
   <IconText
-    icon={<IconInfo size={theme.icon.size.medium} />}
+    icon={icon}
     text={label}
     style={{
       containerStyle,

--- a/src/components/__tests__/DocumentLinks.test.tsx
+++ b/src/components/__tests__/DocumentLinks.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { render, fireEvent } from '@testing-library/react-native'
+
+import DocumentLink from '../DocumentLink'
+
+const onPress = jest.fn()
+describe('DocumentLink', () => {
+  test('Rendering', () => {
+    const { toJSON } = render(<DocumentLink onPress={onPress} containerStyle={{ flex: 1 }} label="Privacy statement" />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  test('Click', async () => {
+    const { getByText } = render(
+      <DocumentLink onPress={onPress} containerStyle={{ flex: 1 }} label="Privacy statement" />,
+    )
+    await fireEvent.press(getByText('Privacy statement'))
+    expect(onPress).toBeCalled()
+  })
+})

--- a/src/components/__tests__/__snapshots__/BottomSheet.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomSheet.test.tsx.snap
@@ -21,11 +21,15 @@ exports[`BottomSheet Rendering Only buttons 1`] = `
 >
   <View
     style={
-      {
-        "backgroundColor": "white",
-        "elevation": 6,
-        "shadowColor": "#939393",
-      }
+      [
+        {
+          "elevation": 6,
+          "shadowColor": "#939393",
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 255)",
+        },
+      ]
     }
   >
     <View
@@ -155,11 +159,15 @@ exports[`BottomSheet Rendering With button 1`] = `
 >
   <View
     style={
-      {
-        "backgroundColor": "white",
-        "elevation": 6,
-        "shadowColor": "#939393",
-      }
+      [
+        {
+          "elevation": 6,
+          "shadowColor": "#939393",
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 255)",
+        },
+      ]
     }
   >
     <View
@@ -334,11 +342,15 @@ exports[`BottomSheet Rendering With children 1`] = `
 >
   <View
     style={
-      {
-        "backgroundColor": "white",
-        "elevation": 6,
-        "shadowColor": "#939393",
-      }
+      [
+        {
+          "elevation": 6,
+          "shadowColor": "#939393",
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 255)",
+        },
+      ]
     }
   >
     <View
@@ -386,11 +398,15 @@ exports[`BottomSheet Rendering Without icon 1`] = `
 >
   <View
     style={
-      {
-        "backgroundColor": "white",
-        "elevation": 6,
-        "shadowColor": "#939393",
-      }
+      [
+        {
+          "elevation": 6,
+          "shadowColor": "#939393",
+        },
+        {
+          "backgroundColor": "rgb(255, 255, 255)",
+        },
+      ]
     }
   >
     <View

--- a/src/components/__tests__/__snapshots__/DocumentLinks.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DocumentLinks.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`DocumentLink Rendering 1`] = `
         color="#0066B1"
         name="file-lines"
         size={14}
-        type="light"
+        type="solid"
       />
     </View>
     <Text

--- a/src/components/__tests__/__snapshots__/DocumentLinks.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DocumentLinks.test.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentLink Rendering 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "opacity": 1,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "flexDirection": "row",
+        },
+        {
+          "flex": 1,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "justifyContent": "center",
+            "marginRight": 8,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Icon
+        color="#0066B1"
+        name="file-lines"
+        size={14}
+        type="light"
+      />
+    </View>
+    <Text
+      style={
+        [
+          {
+            "flexShrink": 1,
+          },
+          {
+            "color": "#0066B1",
+            "fontFamily": "Ubuntu",
+            "fontSize": 14,
+            "fontStyle": "normal",
+            "fontWeight": "normal",
+            "lineHeight": 20,
+          },
+        ]
+      }
+    >
+      Privacy statement
+    </Text>
+  </View>
+</View>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import Chip from './components/Chip'
 import ContentImage from './components/ContentImage'
 import Date from './components/Date'
 import Disclose from './components/Disclose'
+import DocumentLink from './components/DocumentLink'
 import FilterButton from './components/FilterButton'
 import IconButton from './components/IconButton'
 import IconText from './components/IconText'
@@ -44,6 +45,7 @@ export {
   ContentImage,
   Date,
   Disclose,
+  DocumentLink,
   FilterButton,
   IconButton,
   IconText,

--- a/src/lib/Icons.ts
+++ b/src/lib/Icons.ts
@@ -41,6 +41,7 @@ import { faHeart as faHeartLight } from '@fortawesome/pro-light-svg-icons/faHear
 import { faHexagon as faHexagonLight } from '@fortawesome/pro-light-svg-icons/faHexagon'
 import { faImages as faImagesLight } from '@fortawesome/pro-light-svg-icons/faImages'
 import { faInfoCircle as faInfoCircleLight } from '@fortawesome/pro-light-svg-icons/faInfoCircle'
+import { faInfoSquare as faInfoSquareLight } from '@fortawesome/pro-light-svg-icons/faInfoSquare'
 import { faLanguage as faLanguageLight } from '@fortawesome/pro-light-svg-icons/faLanguage'
 import { faMapMarkerAlt as faMapMarkerAltLight } from '@fortawesome/pro-light-svg-icons/faMapMarkerAlt'
 import { faPaperPlaneTop as faPaperPlaneToplight } from '@fortawesome/pro-light-svg-icons/faPaperPlaneTop'
@@ -106,6 +107,7 @@ import { faHeart as faHeartSolid } from '@fortawesome/pro-solid-svg-icons/faHear
 import { faHexagon as faHexagonSolid } from '@fortawesome/pro-solid-svg-icons/faHexagon'
 import { faImages as faImagesSolid } from '@fortawesome/pro-solid-svg-icons/faImages'
 import { faInfoCircle as faInfoCircleSolid } from '@fortawesome/pro-solid-svg-icons/faInfoCircle'
+import { faInfoSquare as faInfoSquareSolid } from '@fortawesome/pro-solid-svg-icons/faInfoSquare'
 import { faLanguage as faLanguageSolid } from '@fortawesome/pro-solid-svg-icons/faLanguage'
 import { faMapMarkerAlt as faMapMarkerAltSolid } from '@fortawesome/pro-solid-svg-icons/faMapMarkerAlt'
 import { faPaperPlaneTop as faPaperPlaneTopSolid } from '@fortawesome/pro-solid-svg-icons/faPaperPlaneTop'
@@ -165,6 +167,7 @@ type IconName =
   | 'hide'
   | 'image-gallery'
   | 'info'
+  | 'info-square'
   | 'language'
   | 'like'
   | 'list'
@@ -234,6 +237,7 @@ const icons: { [key in IconName]: { light: IconDefinition; solid: IconDefinition
   hide: { light: faEyeSlashLight, solid: faEyeSlashSolid },
   'image-gallery': { light: faImagesLight, solid: faImagesSolid },
   info: { light: faInfoCircleLight, solid: faInfoCircleSolid },
+  'info-square': { light: faInfoSquareLight, solid: faInfoSquareSolid },
   language: { light: faLanguageLight, solid: faLanguageSolid },
   like: { light: faHeartLight, solid: faHeartSolid },
   list: { light: faAlignJustifyLight, solid: faAlignJustifySolid },

--- a/src/lib/Icons.ts
+++ b/src/lib/Icons.ts
@@ -49,6 +49,7 @@ import { faQrcode as faQrcodeLight } from '@fortawesome/pro-light-svg-icons/faQr
 import { faQuestionSquare as faQuestionSquareLight } from '@fortawesome/pro-light-svg-icons/faQuestionSquare'
 import { faRandom as faRandomLight } from '@fortawesome/pro-light-svg-icons/faRandom'
 import { faRectangleHistory as faRectangleHistoryLight } from '@fortawesome/pro-light-svg-icons/faRectangleHistory'
+import { faRightToBracket as faRightToBracketLight } from '@fortawesome/pro-light-svg-icons/faRightToBracket'
 import { faShareNodes as faShareNodesLight } from '@fortawesome/pro-light-svg-icons/faShareNodes'
 import { faSlidersH as faSlidersHLight } from '@fortawesome/pro-light-svg-icons/faSlidersH'
 import { faSquare as faSquareLight } from '@fortawesome/pro-light-svg-icons/faSquare'
@@ -112,6 +113,7 @@ import { faQrcode as faQrcodeSolid } from '@fortawesome/pro-solid-svg-icons/faQr
 import { faQuestionSquare as faQuestionSquareSolid } from '@fortawesome/pro-solid-svg-icons/faQuestionSquare'
 import { faRandom as faRandomSolid } from '@fortawesome/pro-solid-svg-icons/faRandom'
 import { faRectangleHistory as faRectangleHistorySolid } from '@fortawesome/pro-solid-svg-icons/faRectangleHistory'
+import { faRightToBracket as faRightToBracketSolid } from '@fortawesome/pro-solid-svg-icons/faRightToBracket'
 import { faShareNodes as faShareNodesSolid } from '@fortawesome/pro-solid-svg-icons/faShareNodes'
 import { faSlidersH as faSlidersHSolid } from '@fortawesome/pro-solid-svg-icons/faSlidersH'
 import { faSquare as faSquareSolid } from '@fortawesome/pro-solid-svg-icons/faSquare'
@@ -165,6 +167,7 @@ type IconName =
   | 'like'
   | 'list'
   | 'location'
+  | 'login'
   | 'new'
   | 'next'
   | 'photography'
@@ -232,6 +235,7 @@ const icons: { [key in IconName]: { light: IconDefinition; solid: IconDefinition
   like: { light: faHeartLight, solid: faHeartSolid },
   list: { light: faAlignJustifyLight, solid: faAlignJustifySolid },
   location: { light: faMapMarkerAltLight, solid: faMapMarkerAltSolid },
+  login: { light: faRightToBracketLight, solid: faRightToBracketSolid },
   new: { light: faStarsLight, solid: faStarsSolid },
   next: { light: faChevronCircleRightLight, solid: faChevronCircleRightSolid },
   photography: { light: faCameraLight, solid: faCameraSolid },

--- a/src/lib/Icons.ts
+++ b/src/lib/Icons.ts
@@ -42,7 +42,6 @@ import { faHeart as faHeartLight } from '@fortawesome/pro-light-svg-icons/faHear
 import { faHexagon as faHexagonLight } from '@fortawesome/pro-light-svg-icons/faHexagon'
 import { faImages as faImagesLight } from '@fortawesome/pro-light-svg-icons/faImages'
 import { faInfoCircle as faInfoCircleLight } from '@fortawesome/pro-light-svg-icons/faInfoCircle'
-import { faInfoSquare as faInfoSquareLight } from '@fortawesome/pro-light-svg-icons/faInfoSquare'
 import { faLanguage as faLanguageLight } from '@fortawesome/pro-light-svg-icons/faLanguage'
 import { faMapMarkerAlt as faMapMarkerAltLight } from '@fortawesome/pro-light-svg-icons/faMapMarkerAlt'
 import { faPaperPlaneTop as faPaperPlaneToplight } from '@fortawesome/pro-light-svg-icons/faPaperPlaneTop'
@@ -109,7 +108,6 @@ import { faHeart as faHeartSolid } from '@fortawesome/pro-solid-svg-icons/faHear
 import { faHexagon as faHexagonSolid } from '@fortawesome/pro-solid-svg-icons/faHexagon'
 import { faImages as faImagesSolid } from '@fortawesome/pro-solid-svg-icons/faImages'
 import { faInfoCircle as faInfoCircleSolid } from '@fortawesome/pro-solid-svg-icons/faInfoCircle'
-import { faInfoSquare as faInfoSquareSolid } from '@fortawesome/pro-solid-svg-icons/faInfoSquare'
 import { faLanguage as faLanguageSolid } from '@fortawesome/pro-solid-svg-icons/faLanguage'
 import { faMapMarkerAlt as faMapMarkerAltSolid } from '@fortawesome/pro-solid-svg-icons/faMapMarkerAlt'
 import { faPaperPlaneTop as faPaperPlaneTopSolid } from '@fortawesome/pro-solid-svg-icons/faPaperPlaneTop'
@@ -170,7 +168,6 @@ type IconName =
   | 'hide'
   | 'image-gallery'
   | 'info'
-  | 'info-square'
   | 'language'
   | 'like'
   | 'list'
@@ -241,7 +238,6 @@ const icons: { [key in IconName]: { light: IconDefinition; solid: IconDefinition
   hide: { light: faEyeSlashLight, solid: faEyeSlashSolid },
   'image-gallery': { light: faImagesLight, solid: faImagesSolid },
   info: { light: faInfoCircleLight, solid: faInfoCircleSolid },
-  'info-square': { light: faInfoSquareLight, solid: faInfoSquareSolid },
   language: { light: faLanguageLight, solid: faLanguageSolid },
   like: { light: faHeartLight, solid: faHeartSolid },
   list: { light: faAlignJustifyLight, solid: faAlignJustifySolid },

--- a/src/lib/Icons.ts
+++ b/src/lib/Icons.ts
@@ -25,6 +25,7 @@ import { faChevronLeft as faChevronLeftLight } from '@fortawesome/pro-light-svg-
 import { faChevronRight as faChevronRightLight } from '@fortawesome/pro-light-svg-icons/faChevronRight'
 import { faCircle as faCircleLight } from '@fortawesome/pro-light-svg-icons/faCircle'
 import { faCircleCheck as faCircleCheckLight } from '@fortawesome/pro-light-svg-icons/faCircleCheck'
+import { faCirclePlus as faCirclePlusLight } from '@fortawesome/pro-light-svg-icons/faCirclePlus'
 import { faCircleUser as faCircleUserLight } from '@fortawesome/pro-light-svg-icons/faCircleUser'
 import { faClone as faCloneLight } from '@fortawesome/pro-light-svg-icons/faClone'
 import { faCog as faCogLight } from '@fortawesome/pro-light-svg-icons/faCog'
@@ -89,6 +90,7 @@ import { faChevronLeft as faChevronLeftSolid } from '@fortawesome/pro-solid-svg-
 import { faChevronRight as faChevronRightSolid } from '@fortawesome/pro-solid-svg-icons/faChevronRight'
 import { faCircle as faCircleSolid } from '@fortawesome/pro-solid-svg-icons/faCircle'
 import { faCircleCheck as faCircleCheckSolid } from '@fortawesome/pro-solid-svg-icons/faCircleCheck'
+import { faCirclePlus as faCirclePlusSolid } from '@fortawesome/pro-solid-svg-icons/faCirclePlus'
 import { faCircleUser as faCircleUserSolid } from '@fortawesome/pro-solid-svg-icons/faCircleUser'
 import { faClone as faCloneSolid } from '@fortawesome/pro-solid-svg-icons/faClone'
 import { faCog as faCogSolid } from '@fortawesome/pro-solid-svg-icons/faCog'
@@ -188,6 +190,7 @@ type IconName =
   | 'show'
   | 'statistics'
   | 'success'
+  | 'tab-add'
   | 'undo'
   | 'upload'
   | 'user'
@@ -259,6 +262,7 @@ const icons: { [key in IconName]: { light: IconDefinition; solid: IconDefinition
   show: { light: faEyeLight, solid: faEyeSolid },
   statistics: { light: faChartColumnLight, solid: faChartColumnSolid },
   success: { light: faCircleCheckLight, solid: faCircleCheckSolid },
+  'tab-add': { light: faCirclePlusLight, solid: faCirclePlusSolid },
   undo: { light: faUndoLight, solid: faUndoSolid },
   upload: { light: faArrowUpFromBracketLight, solid: faArrowUpFromBracketSolid },
   user: { light: faUserLight, solid: faUserSolid },

--- a/src/lib/Icons.ts
+++ b/src/lib/Icons.ts
@@ -36,6 +36,7 @@ import { faExclamationTriangle as faExclamationTriangleLight } from '@fortawesom
 import { faExternalLink as faExternalLinkLight } from '@fortawesome/pro-light-svg-icons/faExternalLink'
 import { faEye as faEyeLight } from '@fortawesome/pro-light-svg-icons/faEye'
 import { faEyeSlash as faEyeSlashLight } from '@fortawesome/pro-light-svg-icons/faEyeSlash'
+import { faFileLines as faFileLinesLight } from '@fortawesome/pro-light-svg-icons/faFileLines'
 import { faGlobeEurope as faGlobeEuropeLight } from '@fortawesome/pro-light-svg-icons/faGlobeEurope'
 import { faHeart as faHeartLight } from '@fortawesome/pro-light-svg-icons/faHeart'
 import { faHexagon as faHexagonLight } from '@fortawesome/pro-light-svg-icons/faHexagon'
@@ -102,6 +103,7 @@ import { faExclamationTriangle as faExclamationTriangleSolid } from '@fortawesom
 import { faExternalLink as faExternalLinkSolid } from '@fortawesome/pro-solid-svg-icons/faExternalLink'
 import { faEye as faEyeSolid } from '@fortawesome/pro-solid-svg-icons/faEye'
 import { faEyeSlash as faEyeSlashSolid } from '@fortawesome/pro-solid-svg-icons/faEyeSlash'
+import { faFileLines as faFileLinesSolid } from '@fortawesome/pro-solid-svg-icons/faFileLines'
 import { faGlobeEurope as faGlobeEuropeSolid } from '@fortawesome/pro-solid-svg-icons/faGlobeEurope'
 import { faHeart as faHeartSolid } from '@fortawesome/pro-solid-svg-icons/faHeart'
 import { faHexagon as faHexagonSolid } from '@fortawesome/pro-solid-svg-icons/faHexagon'
@@ -162,6 +164,7 @@ type IconName =
   | 'exclusion'
   | 'expand'
   | 'external-link'
+  | 'document'
   | 'feed'
   | 'group'
   | 'hide'
@@ -224,6 +227,7 @@ const icons: { [key in IconName]: { light: IconDefinition; solid: IconDefinition
   'date-range': { light: faCalendarRangeLight, solid: faCalendarRangeSolid },
   delete: { light: faTrashAltLight, solid: faTrashAltSolid },
   disclose: { light: faChevronRightLight, solid: faChevronRightSolid },
+  document: { light: faFileLinesLight, solid: faFileLinesSolid },
   email: { light: faEnvelopeLight, solid: faEnvelopeSolid },
   enumeration: { light: faCircleLight, solid: faCircleSolid },
   error: { light: faExclamationTriangleLight, solid: faExclamationTriangleSolid },


### PR DESCRIPTION
Changes needed for https://github.com/observation/app/issues/21:
- Added icons for login, tab add and document
- Added DocumentLink component
- Use the react natigation theme for background color of BottomSheet
- Configure the CI to run checks and tests