### PR TITLE
Upgrade version number in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observation.org/react-native-components",
-  "version": "1.0.0",
+  "version": "1.7.0",
   "main": "src/index.ts",
   "repository": "git@github.com:observation/react-native-components.git",
   "author": "Observation.org",


### PR DESCRIPTION
Every time `yarn` is run and a different version of this library has been previously checked out, I notice that v1.0.0 is downloaded instead of the actual version hidden in the tag. This resolves that issue. This way, yarn.lock is also updated with the correct version of this library.