### PR TITLE
Use fixed react-native-image-viewing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ on: [push]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-      - name: Authenticate with FontAwesome Pro
-        run: echo "//npm.fontawesome.com/:_authToken=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}" >> .npmrc && cat .npmrc
       - name: Install modules
         run: yarn
       - name: Run lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observation.org/react-native-components",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "main": "src/index.ts",
   "repository": "git@github.com:observation/react-native-components.git",
   "author": "Observation.org",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,7 +1551,7 @@
 
 "@observation.org/react-native-image-viewing@https://github.com/observation/react-native-image-viewing":
   version "0.2.2"
-  resolved "https://github.com/observation/react-native-image-viewing#2e2716d7d072b88241266a6eb0023251373d1a07"
+  resolved "https://github.com/observation/react-native-image-viewing#06772aee6d72f5538c540390db2eefa101374bc1"
 
 "@pkgr/core@^0.1.0":
   version "0.1.1"


### PR DESCRIPTION
Include a version of react-native-image-viewing that supports use in React Native 0.74.

Verified that the change works for both Observation @ RN 0.73 and ObsIdentify @ RN 0.74.

Also, configured `.nvmrc` to use the font awesome authentication token from an environment variable, and configured CI to set this environment variable from a repository secret. For a local development environment, this token should be setup in the environment of the shell, e.g. `~/.profile`.