### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ jobs:
       FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+      - name: Cache Yarn cache and node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+            node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
       - name: Install modules
         run: yarn
       - name: Run lint


### PR DESCRIPTION
Cache both Yarn’s .yarn/cache and node_modules to avoid reinstalling dependencies on every run. This speeds up a run from ~2min to <1min.