### PR TITLE
Prevent unnecessary rerenders for RenderHtml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observation.org/react-native-components",
-  "version": "1.66.0",
+  "version": "1.67.0",
   "main": "src/index.ts",
   "repository": "git@github.com:observation/react-native-components.git",
   "author": "Observation.org",

--- a/src/components/RenderHtmlWrapper.tsx
+++ b/src/components/RenderHtmlWrapper.tsx
@@ -46,30 +46,30 @@ const renderers = {
   ul: ulRenderer,
 }
 
+const defaultRenderersProps = {
+  a: {
+    onPress: (_event: GestureResponderEvent, href: string) => openUrl(href),
+  },
+}
+
+const systemFonts = [...defaultSystemFonts, 'Ubuntu']
+
 const RenderHtmlWrapper = ({
   contentWidth = Dimensions.get('window').width - 2 * theme.margin.common,
-  renderersProps = {
-    a: {
-      onPress: (_event: GestureResponderEvent, href: string) => openUrl(href),
-    },
-  },
+  renderersProps = defaultRenderersProps,
   baseStyle = textStyle.body,
   ...props
-}: RenderHTMLProps) => {
-  const systemFonts = [...defaultSystemFonts, 'Ubuntu']
-
-  return (
-    <RenderHtml
-      contentWidth={contentWidth}
-      renderersProps={renderersProps}
-      renderers={renderers}
-      systemFonts={systemFonts}
-      baseStyle={baseStyle}
-      tagsStyles={htmlStyle}
-      enableExperimentalMarginCollapsing
-      {...props}
-    />
-  )
-}
+}: RenderHTMLProps) => (
+  <RenderHtml
+    contentWidth={contentWidth}
+    renderersProps={renderersProps}
+    renderers={renderers}
+    systemFonts={systemFonts}
+    baseStyle={baseStyle}
+    tagsStyles={htmlStyle}
+    enableExperimentalMarginCollapsing
+    {...props}
+  />
+)
 
 export default RenderHtmlWrapper


### PR DESCRIPTION
Because `systemFonts` changes every rerender, the component needs to update. This is visible when you run the unit test "HtmlPageView > Interactions > When the Show more button is pressed, the content is expanded" with logging on:
```
 FAIL  src/species/components/__tests__/HtmlPageView.test.tsx
  HtmlPageView
    Rendering
      ○ skipped Collapsed view
      ○ skipped Expanded view
    Interactions
      ✕ When the Show more button is pressed, the content is expanded (83 ms)
      ○ skipped When the Show less button is pressed, the content is collapsed

  ● HtmlPageView › Interactions › When the Show more button is pressed, the content is expanded

    Expected test not to call console.warn().

    If the warn is expected, test for it explicitly by mocking it out using jest.spyOn(console, 'warn').mockImplementation() and test that the warning occurs.

    You seem to update props of the "TRenderEngineProvider" component in short periods of time, causing costly tree rerenders (last update was 46.00ms ago). See https://stackoverflow.com/q/68966120/2779871
```