### PR TITLE
Add textInputComponent prop to InputField

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observation.org/react-native-components",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -17,6 +17,7 @@ type Props = {
   description?: string
   errorMessage?: string
   disabled?: boolean
+  textInputComponent?: React.ComponentType<any>
 }
 
 const InputField = ({
@@ -30,6 +31,7 @@ const InputField = ({
   description,
   errorMessage,
   disabled = false,
+  textInputComponent: TextInputComponent = TextInput,
 }: Props) => {
   const theme = useTheme()
   const styles = useStyles(createStyles)
@@ -68,7 +70,7 @@ const InputField = ({
         </View>
       )}
       <View style={{ flexDirection: 'row', ...inputContainerStyle }}>
-        <TextInput
+        <TextInputComponent
           ref={inputRef}
           style={[{ borderColor }, styles.inputStyle, inputStyle, fixInputStyle]}
           {...inputProps}

--- a/src/components/__tests__/InputField.test.tsx
+++ b/src/components/__tests__/InputField.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { TextInput } from 'react-native'
 
 import { act, render } from '@testing-library/react-native'
 
 import { Icon } from '../Icon'
 import InputField from '../InputField'
+
+class CustomTextInput extends TextInput {}
 
 describe('InputField', () => {
   describe('Rendering', () => {
@@ -83,6 +86,14 @@ describe('InputField', () => {
     test('With a description', () => {
       // GIVEN
       const { toJSON } = render(<InputField description="The description" />)
+
+      // THEN
+      expect(toJSON()).toMatchSnapshot()
+    })
+
+    test('With an alternative TextInput component', () => {
+      // GIVEN
+      const { toJSON } = render(<InputField description="The description" textInputComponent={CustomTextInput} />)
 
       // THEN
       expect(toJSON()).toMatchSnapshot()

--- a/src/components/__tests__/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/InputField.test.tsx.snap
@@ -348,6 +348,81 @@ exports[`InputField Rendering With a right icon 1`] = `
 </View>
 `;
 
+exports[`InputField Rendering With an alternative TextInput component 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "column",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <TextInput
+      autoCapitalize="none"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      placeholderTextColor="#939393"
+      style={
+        [
+          {
+            "borderColor": "#E6E6E6",
+          },
+          {
+            "borderRadius": 4,
+            "borderWidth": 2,
+            "color": "#212121",
+            "flex": 1,
+            "fontFamily": "Ubuntu",
+            "fontSize": 16,
+            "fontStyle": "normal",
+            "fontWeight": "normal",
+            "lineHeight": 24,
+            "minHeight": 40,
+            "overflow": "hidden",
+            "paddingLeft": 8,
+            "paddingRight": 32,
+          },
+          undefined,
+          {
+            "lineHeight": 0,
+          },
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </View>
+  <Text
+    style={
+      [
+        {
+          "marginTop": 8,
+        },
+        {
+          "color": "#666666",
+          "fontFamily": "Ubuntu",
+          "fontSize": 12,
+          "fontStyle": "normal",
+          "fontWeight": "normal",
+          "lineHeight": 16,
+        },
+        undefined,
+      ]
+    }
+  >
+    The description
+  </Text>
+</View>
+`;
+
 exports[`InputField Rendering With an error message 1`] = `
 <View
   style={


### PR DESCRIPTION
Necessary to make https://github.com/observation/app/pull/1212 pass.

This adds a new prop to the InputField component. It allows you to pass down another `TextInput`-like component. In this case we need it to be able to pass down a `BottomSheetTextInput` component.

The typing of the new prop is set to `any` because this library does not know about `BottomSheetTextInput`. Typing it as `TextInput` does not help because `BottomSheetTextInput` is a superset of `TextInput`. So `any` seems most appropriate.