### PR TITLE
Show the map for a session

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observation.org/react-native-components",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",

--- a/src/lib/Icons.ts
+++ b/src/lib/Icons.ts
@@ -10,6 +10,7 @@ import { faArrowsRotate as faArrowsRotateLight } from '@fortawesome/pro-light-sv
 import { faArrowTurnRight as faArrowTurnRightLight } from '@fortawesome/pro-light-svg-icons/faArrowTurnRight'
 import { faArrowUpFromBracket as faArrowUpFromBracketLight } from '@fortawesome/pro-light-svg-icons/faArrowUpFromBracket'
 import { faArrowUpFromSquare as faArrowUpFromSquareLight } from '@fortawesome/pro-light-svg-icons/faArrowUpFromSquare'
+import { faArrowUpRightAndArrowDownLeftFromCenter as faArrowUpRightAndArrowDownLeftFromCenterLight } from '@fortawesome/pro-light-svg-icons/faArrowUpRightAndArrowDownLeftFromCenter'
 import { faBadge as faBadgeLight } from '@fortawesome/pro-light-svg-icons/faBadge'
 import { faBadgeCheck as faBadgeCheckLight } from '@fortawesome/pro-light-svg-icons/faBadgeCheck'
 import { faBanBug as faBanBugLight } from '@fortawesome/pro-light-svg-icons/faBanBug'
@@ -113,6 +114,7 @@ import { faArrowsRotate as faArrowsRotateSolid } from '@fortawesome/pro-solid-sv
 import { faArrowTurnRight as faArrowTurnRightSolid } from '@fortawesome/pro-solid-svg-icons/faArrowTurnRight'
 import { faArrowUpFromBracket as faArrowUpFromBracketSolid } from '@fortawesome/pro-solid-svg-icons/faArrowUpFromBracket'
 import { faArrowUpFromSquare as faArrowUpFromSquareSolid } from '@fortawesome/pro-solid-svg-icons/faArrowUpFromSquare'
+import { faArrowUpRightAndArrowDownLeftFromCenter as faArrowUpRightAndArrowDownLeftFromCenterSolid } from '@fortawesome/pro-solid-svg-icons/faArrowUpRightAndArrowDownLeftFromCenter'
 import { faBadge as faBadgeSolid } from '@fortawesome/pro-solid-svg-icons/faBadge'
 import { faBadgeCheck as faBadgeCheckSolid } from '@fortawesome/pro-solid-svg-icons/faBadgeCheck'
 import { faBanBug as faBanBugSolid } from '@fortawesome/pro-solid-svg-icons/faBanBug'
@@ -218,6 +220,7 @@ type IconName = Extract<
   | 'arrow-turn-right'
   | 'arrow-up-from-bracket'
   | 'arrow-up-from-square'
+  | 'arrow-up-right-and-arrow-down-left-from-center'
   | 'arrows-rotate'
   | 'badge'
   | 'badge-check'
@@ -323,6 +326,10 @@ const icons: { [key in IconName]: { light: IconDefinition; solid: IconDefinition
   'arrow-turn-right': { light: faArrowTurnRightLight, solid: faArrowTurnRightSolid },
   'arrow-up-from-bracket': { light: faArrowUpFromBracketLight, solid: faArrowUpFromBracketSolid },
   'arrow-up-from-square': { light: faArrowUpFromSquareLight, solid: faArrowUpFromSquareSolid },
+  'arrow-up-right-and-arrow-down-left-from-center': {
+    light: faArrowUpRightAndArrowDownLeftFromCenterLight,
+    solid: faArrowUpRightAndArrowDownLeftFromCenterSolid,
+  },
   'arrows-rotate': { light: faArrowsRotateLight, solid: faArrowsRotateSolid },
   'arrow-rotate-left': { light: faArrowRotateLeftLight, solid: faArrowRotateLeftSolid },
   'badge-check': { light: faBadgeCheckLight, solid: faBadgeCheckSolid },

--- a/src/theme/tokens/color.ts
+++ b/src/theme/tokens/color.ts
@@ -101,6 +101,8 @@ export const color = {
       default: paletteMode.grey[300],
       subtle: paletteMode.grey[50],
       focus: paletteMode.primary[300],
+      transect: paletteMode.error[500],
+      transectBorder: paletteMode.base['white'],
     },
     status: {
       uploadable: paletteMode.accentSky[400],

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -188,6 +188,8 @@ export interface Color {
       default: string
       subtle: string
       focus: string
+      transect: string
+      transectBorder: string
     }
     status: {
       uploadable: string


### PR DESCRIPTION
Changes for https://github.com/observation/app/issues/1254:
- Add icon `arrow-up-right-and-arrow-down-left-from-center`
- Add semantic color names for drawing the transect on the map