### PR TITLE
Memoize rarity options in RaritySlider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observation.org/react-native-components",
-  "version": "1.85.0",
+  "version": "1.86.0",
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",

--- a/src/components/RaritySlider.tsx
+++ b/src/components/RaritySlider.tsx
@@ -44,7 +44,7 @@ const RaritySlider = ({ rarities, onChange, value }: Props) => {
 
   const { width } = useWindowDimensions()
 
-  const options = rarities.filter((r) => r.id !== Config.rarityId.unknown)
+  const options = useMemo(() => rarities.filter((r) => r.id !== Config.rarityId.unknown), [rarities])
   const rarityWidth = (width - margin * 2) / options.length
   const rarityConfig = Config.rarityConfig(theme)
 


### PR DESCRIPTION
Een kleine verbetering waardoor de `useEffect` niet elke keer wordt aangeroepen als iets in het `ObservationFilter` wordt aangepast.